### PR TITLE
feat(client): expose collection-level JSON Patch for bulk create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project are documented in this file.
 
+## [1.1.9] - 2026-05-10
+
+### Added
+- Collection-level JSON Patch support on `TmfClient` / `TmfClientBaseImpl`. Adds 4 + 4
+  `patchCollection(...)` / `patchCollectionWithToken(...)` overloads that issue a `PATCH` against
+  the collection root (no `/{id}` segment) with content-type `application/json-patch+json` and
+  return `Mono<List<R>>` (or `Mono<List<T>>` with a custom return type). This supports the TMF v4
+  high-performance bulk-creation pattern (RFC 6902 JSON Patch with `add /` operations). Pure
+  addition: no existing signatures change.
+
 ## [1.1.8] - 2026-02-27
 
 ### Changed

--- a/src/main/java/org/opentmf/common/client/api/TmfClient.java
+++ b/src/main/java/org/opentmf/common/client/api/TmfClient.java
@@ -1,6 +1,7 @@
 package org.opentmf.common.client.api;
 
 import com.github.fge.jsonpatch.JsonPatch;
+import java.util.List;
 import org.opentmf.common.model.TmfPage;
 import org.opentmf.common.model.TmfRequestContext;
 import org.springframework.data.domain.Pageable;
@@ -95,6 +96,34 @@ public interface TmfClient<C, U, R> {
   Mono<R> patchWithToken(String token, String id, JsonPatch jsonPatch, TmfRequestContext requestContext);
   <T> Mono<T> patchWithToken(String token, String id, JsonPatch jsonPatch, Class<T> type);
   <T> Mono<T> patchWithToken(String token, String id, JsonPatch jsonPatch, TmfRequestContext requestContext, Class<T> type);
+
+  /**
+   * Collection-level JSON Patch (TMF v4 high-performance bulk-creation pattern).
+   *
+   * <p>Issues {@code PATCH} against the collection root (no {@code /{id}} suffix) with
+   * content-type {@code application/json-patch+json}. The request body is an RFC 6902 JSON Patch
+   * (typically a sequence of {@code add} operations on path {@code "/"}, each carrying one full
+   * resource), and the server responds with a JSON array of created resources in the same order
+   * as the patch operations.
+   *
+   * <p>This complements {@link #patch(String, JsonPatch)} which targets a single resource by id;
+   * {@code patchCollection} targets the collection itself.
+   *
+   * <p>Access token is retrieved automatically.
+   */
+  Mono<List<R>> patchCollection(JsonPatch jsonPatch);
+  Mono<List<R>> patchCollection(JsonPatch jsonPatch, TmfRequestContext requestContext);
+  <T> Mono<List<T>> patchCollection(JsonPatch jsonPatch, Class<T> type);
+  <T> Mono<List<T>> patchCollection(JsonPatch jsonPatch, TmfRequestContext requestContext, Class<T> type);
+
+  /**
+   * Collection-level JSON Patch (TMF v4 high-performance bulk-creation pattern), using the
+   * provided access token. See {@link #patchCollection(JsonPatch)} for behavior.
+   */
+  Mono<List<R>> patchCollectionWithToken(String token, JsonPatch jsonPatch);
+  Mono<List<R>> patchCollectionWithToken(String token, JsonPatch jsonPatch, TmfRequestContext requestContext);
+  <T> Mono<List<T>> patchCollectionWithToken(String token, JsonPatch jsonPatch, Class<T> type);
+  <T> Mono<List<T>> patchCollectionWithToken(String token, JsonPatch jsonPatch, TmfRequestContext requestContext, Class<T> type);
 
   /** Delete a single object by its id (access token retrieved automatically) */
   Mono<Void> delete(String id);

--- a/src/main/java/org/opentmf/common/client/impl/TmfClientBaseImpl.java
+++ b/src/main/java/org/opentmf/common/client/impl/TmfClientBaseImpl.java
@@ -5,6 +5,7 @@ import static org.opentmf.common.util.TmfClientCommonUtil.createException;
 import static org.opentmf.common.util.TmfClientCommonUtil.findStatusText;
 
 import com.github.fge.jsonpatch.JsonPatch;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
@@ -437,6 +438,60 @@ public abstract class TmfClientBaseImpl<C, U, R> implements TmfClient<C, U, R> {
       Class<T> type) {
     var uri = TmfClientCommonUtil.buildUriWithId(getClientConfig(), id, requestContext);
     return TmfClientCommonUtil.patchRequest(
+        getWebClient(),
+        uri,
+        jsonPatch,
+        TmfClientCommonHeaderUtil.prepareHeaderConsumer(
+            token, getClientConfig(), requestContext, getTokenService()),
+        this::handleError,
+        type,
+        getClientProperties());
+  }
+
+  @Override
+  public Mono<List<R>> patchCollection(JsonPatch jsonPatch) {
+    return patchCollection(jsonPatch, getType());
+  }
+
+  @Override
+  public Mono<List<R>> patchCollection(JsonPatch jsonPatch, TmfRequestContext requestContext) {
+    return patchCollection(jsonPatch, requestContext, getType());
+  }
+
+  @Override
+  public <T> Mono<List<T>> patchCollection(JsonPatch jsonPatch, Class<T> type) {
+    return patchCollection(jsonPatch, null, type);
+  }
+
+  @Override
+  public <T> Mono<List<T>> patchCollection(
+      JsonPatch jsonPatch, TmfRequestContext requestContext, Class<T> type) {
+    return getToken(Scope.PATCH)
+        .flatMap(token -> patchCollectionWithToken(token, jsonPatch, requestContext, type));
+  }
+
+  @Override
+  public Mono<List<R>> patchCollectionWithToken(String token, JsonPatch jsonPatch) {
+    return patchCollectionWithToken(token, jsonPatch, getType());
+  }
+
+  @Override
+  public Mono<List<R>> patchCollectionWithToken(
+      String token, JsonPatch jsonPatch, TmfRequestContext requestContext) {
+    return patchCollectionWithToken(token, jsonPatch, requestContext, getType());
+  }
+
+  @Override
+  public <T> Mono<List<T>> patchCollectionWithToken(
+      String token, JsonPatch jsonPatch, Class<T> type) {
+    return patchCollectionWithToken(token, jsonPatch, null, type);
+  }
+
+  @Override
+  public <T> Mono<List<T>> patchCollectionWithToken(
+      String token, JsonPatch jsonPatch, TmfRequestContext requestContext, Class<T> type) {
+    var uri = TmfClientCommonUtil.buildUri(getClientConfig(), requestContext);
+    return TmfClientCommonUtil.patchRequestList(
         getWebClient(),
         uri,
         jsonPatch,

--- a/src/main/java/org/opentmf/common/util/TmfClientCommonUtil.java
+++ b/src/main/java/org/opentmf/common/util/TmfClientCommonUtil.java
@@ -284,6 +284,50 @@ public final class TmfClientCommonUtil {
   }
 
   /**
+   * Executes a collection-level PATCH request (JSON Patch on the collection root) to the specified
+   * URI with the provided JSON patch and access token, expecting a JSON array response. This
+   * supports the TMF v4 high-performance bulk-creation pattern where the request body is an RFC
+   * 6902 JSON Patch carrying a sequence of {@code add} operations on path {@code "/"}, and the
+   * response is a JSON array of created resources in the same order as the patch operations.
+   *
+   * @param webClient The WebClient instance to use for making the request.
+   * @param uri The URI to which the PATCH request is made (collection root, no id segment).
+   * @param jsonPatch The JSON patch to apply.
+   * @param headersConsumer The authentication token used for authorization.
+   * @param errorhandler Function to handle errors.
+   * @param t The class type of each element in the expected response array.
+   * @param properties The properties governing the behavior of the request.
+   * @param <T> The type of each element in the expected response array.
+   * @return A Mono emitting the list of response objects.
+   * @throws NullPointerException if any of the required parameters is null.
+   */
+  public static <T> Mono<List<T>> patchRequestList(
+      WebClient webClient,
+      URI uri,
+      JsonPatch jsonPatch,
+      Consumer<HttpHeaders> headersConsumer,
+      Function<ClientResponse, Mono<? extends Throwable>> errorhandler,
+      Class<T> t,
+      BaseClientProperties properties) {
+    Objects.requireNonNull(
+        jsonPatch, TmfClientCommonsConstants.ERROR_MSG_EMPTY_RESPONSE.formatted(t.getSimpleName()));
+    var headers =
+        prepareAndValidatePatchHeaders(headersConsumer, TmfClientCommonsConstants.MEDIA_TYPE_JSON_PATCH);
+    return webClient
+        .patch()
+        .uri(uri)
+        .headers(httpHeaders -> httpHeaders.addAll(headers))
+        .bodyValue(jsonPatch)
+        .retrieve()
+        .onStatus(HttpStatusCode::isError, errorhandler)
+        .bodyToFlux(t)
+        .collectList()
+        .retryWhen(
+            WebClientUtil.retry(
+                properties.getNumRetries(), Duration.ofMillis(properties.getRetryWaitMillis())));
+  }
+
+  /**
    * Executes a PATCH request to the specified URI with the provided body and access token, handling
    * errors and retries as per the provided properties.
    *

--- a/src/test/java/org/opentmf/common/helper/MockServerUtils.java
+++ b/src/test/java/org/opentmf/common/helper/MockServerUtils.java
@@ -117,6 +117,39 @@ public class MockServerUtils {
         .respond(new DynamicJsonPatchCallback());
   }
 
+  /**
+   * Sets up a static expectation for collection-level JSON Patch (PATCH on the collection root, no
+   * id segment) returning the supplied JSON array body.
+   */
+  public static void setUpCollectionJsonPatchCallback(
+      String path, String responseBody, HttpStatus httpStatus) {
+    clientAndServer
+        .when(
+            request()
+                .withMethod(HttpMethod.PATCH.name())
+                .withPath(path)
+                .withHeader("Content-Type", TmfClientCommonsConstants.MEDIA_TYPE_JSON_PATCH))
+        .respond(
+            response()
+                .withStatusCode(httpStatus.value())
+                .withContentType(APPLICATION_JSON)
+                .withBody(json(responseBody)));
+  }
+
+  /**
+   * Sets up a status-only expectation for collection-level JSON Patch (no body), useful for error
+   * scenarios.
+   */
+  public static void setUpCollectionJsonPatchErrorCallback(String path, HttpStatus httpStatus) {
+    clientAndServer
+        .when(
+            request()
+                .withMethod(HttpMethod.PATCH.name())
+                .withPath(path)
+                .withHeader("Content-Type", TmfClientCommonsConstants.MEDIA_TYPE_JSON_PATCH))
+        .respond(response().withStatusCode(httpStatus.value()));
+  }
+
   public static void setUpDynamicMergePatchCallback(String path) {
     clientAndServer
         .when(

--- a/src/test/java/org/opentmf/common/service/TestTmfClientIT.java
+++ b/src/test/java/org/opentmf/common/service/TestTmfClientIT.java
@@ -13,8 +13,12 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.github.fge.jackson.jsonpointer.JsonPointer;
 import com.github.fge.jackson.jsonpointer.JsonPointerException;
+import com.github.fge.jsonpatch.AddOperation;
 import com.github.fge.jsonpatch.JsonPatch;
+import com.github.fge.jsonpatch.JsonPatchOperation;
 import com.github.fge.jsonpatch.ReplaceOperation;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Assertions;
@@ -26,6 +30,7 @@ import org.opentmf.common.config.TestClientAutoConfiguration;
 import org.opentmf.common.config.TestClientProvider;
 import org.opentmf.common.config.TestTmfClient;
 import org.opentmf.common.config.TmfClientConfigurations;
+import org.opentmf.common.exception.TmfClientException;
 import org.opentmf.common.helper.MockServerUtils;
 import org.opentmf.common.helper.TestResponseClass;
 import org.opentmf.common.helper.TestResponseModel;
@@ -37,6 +42,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.util.LinkedMultiValueMap;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -558,6 +565,142 @@ class TestTmfClientIT {
             testResponseModel -> {
               assertNotNull(testResponseModel);
               assertTrue(testResponseModel.contains("test_patch"));
+            })
+        .verifyComplete();
+  }
+
+  private static JsonPatch buildAddCollectionPatch(int operations) throws JsonPointerException {
+    List<JsonPatchOperation> ops = new ArrayList<>();
+    for (int i = 0; i < operations; i++) {
+      var node = getTestData();
+      node.put("orderNumber", i);
+      ops.add(new AddOperation(new JsonPointer("/"), node));
+    }
+    return new JsonPatch(ops);
+  }
+
+  @Test
+  void test_patchCollection_withMultiOpPatch_shouldReturnListInOrder()
+      throws JsonPointerException {
+    String responseBody =
+        "[{\"id\":\"a-1\",\"name\":\"first\"},"
+            + "{\"id\":\"a-2\",\"name\":\"second\"},"
+            + "{\"id\":\"a-3\",\"name\":\"third\"}]";
+    MockServerUtils.setUpCollectionJsonPatchCallback(path, responseBody, HttpStatus.OK);
+    var patch = buildAddCollectionPatch(3);
+
+    Mono<List<TestResponseModel>> response = testTmfClient.patchCollection(patch);
+
+    StepVerifier.create(response)
+        .assertNext(
+            list -> {
+              assertNotNull(list);
+              assertEquals(3, list.size());
+              assertEquals("a-1", list.get(0).getId());
+              assertEquals("first", list.get(0).getName());
+              assertEquals("a-2", list.get(1).getId());
+              assertEquals("a-3", list.get(2).getId());
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void test_patchCollection_withCustomReturnType_shouldDeserializeIntoList()
+      throws JsonPointerException {
+    String responseBody =
+        "[{\"id\":\"r-1\",\"name\":\"alpha\",\"description\":\"d1\"},"
+            + "{\"id\":\"r-2\",\"name\":\"beta\",\"description\":\"d2\"}]";
+    MockServerUtils.setUpCollectionJsonPatchCallback(path, responseBody, HttpStatus.OK);
+    var patch = buildAddCollectionPatch(2);
+
+    Mono<List<TestResponseClass>> response =
+        testTmfClient.patchCollection(patch, TestResponseClass.class);
+
+    StepVerifier.create(response)
+        .assertNext(
+            list -> {
+              assertNotNull(list);
+              assertEquals(2, list.size());
+              assertEquals("r-1", list.get(0).getId());
+              assertEquals("alpha", list.get(0).getName());
+              assertEquals("r-2", list.get(1).getId());
+              assertEquals("beta", list.get(1).getName());
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void test_patchCollectionWithToken_shouldReturnList() throws JsonPointerException {
+    String responseBody = "[{\"id\":\"t-1\",\"name\":\"with-token\"}]";
+    MockServerUtils.setUpCollectionJsonPatchCallback(path, responseBody, HttpStatus.OK);
+    var patch = buildAddCollectionPatch(1);
+
+    Mono<List<TestResponseModel>> response = testTmfClient.patchCollectionWithToken("token", patch);
+
+    StepVerifier.create(response)
+        .assertNext(
+            list -> {
+              assertNotNull(list);
+              assertEquals(1, list.size());
+              assertEquals("t-1", list.get(0).getId());
+              assertEquals("with-token", list.get(0).getName());
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void test_patchCollection_with4xx_shouldEmitTmfClientException() throws JsonPointerException {
+    MockServerUtils.setUpCollectionJsonPatchErrorCallback(path, HttpStatus.BAD_REQUEST);
+    var patch = buildAddCollectionPatch(2);
+
+    Mono<List<TestResponseModel>> response = testTmfClient.patchCollection(patch);
+
+    StepVerifier.create(response)
+        .expectErrorMatches(
+            error -> {
+              if (error instanceof TmfClientException tmfClientException) {
+                Assertions.assertSame(
+                    HttpStatusCode.valueOf(400), tmfClientException.getStatusCode());
+                return true;
+              }
+              return false;
+            })
+        .verify();
+  }
+
+  @Test
+  void test_patchCollection_with5xx_shouldEmitTmfClientException() throws JsonPointerException {
+    MockServerUtils.setUpCollectionJsonPatchErrorCallback(path, HttpStatus.INTERNAL_SERVER_ERROR);
+    var patch = buildAddCollectionPatch(2);
+
+    Mono<List<TestResponseModel>> response = testTmfClient.patchCollection(patch);
+
+    StepVerifier.create(response)
+        .expectErrorMatches(
+            error -> {
+              if (error instanceof TmfClientException tmfClientException) {
+                Assertions.assertSame(
+                    HttpStatusCode.valueOf(500), tmfClientException.getStatusCode());
+                return true;
+              }
+              return false;
+            })
+        .verify();
+  }
+
+  @Test
+  void test_patchCollection_withEmptyPatch_shouldStillCallServer() {
+    String responseBody = "[]";
+    MockServerUtils.setUpCollectionJsonPatchCallback(path, responseBody, HttpStatus.OK);
+    var patch = new JsonPatch(Collections.emptyList());
+
+    Mono<List<TestResponseModel>> response = testTmfClient.patchCollection(patch);
+
+    StepVerifier.create(response)
+        .assertNext(
+            list -> {
+              assertNotNull(list);
+              assertTrue(list.isEmpty());
             })
         .verifyComplete();
   }


### PR DESCRIPTION
## Why
DRIMS server gained a high-performance bulk creation endpoint (`PATCH /resource` via
RFC 6902 JSON Patch, ~5-7x performance improvement vs legacy `POST /bulkResourceCreate`;
commit `7151db6` in dnext-technology/resource-inventory). The library only exposes
`patch(String id, JsonPatch)` -- single-resource patch. Both
`idemia-drom-ofs-adapter` and `batch-drom-ofs-adapter` had to write their own clients
to fill this gap, duplicating the WebClient + auth + retry + error-mapping logic
that this base library provides.

## What
Adds 4 + 4 collection-level patch overloads to `TmfClient`/`TmfClientBaseImpl`:
- `patchCollection(JsonPatch)` (and `withToken` variant), in 4 form factors
  (auto-token vs token-supplied x default-return vs custom-class).
- HTTP: `PATCH` base-url, content-type `application/json-patch+json`, accept
  `application/json`, response parsed into `Mono<List<R>>` (or `Mono<List<T>>`).
- Same retry / error-mapping / token-acquisition path as existing patch overloads.
- New helper `TmfClientCommonUtil.patchRequestList` mirrors the existing JsonPatch
  variant of `patchRequest` but returns `Mono<List<T>>` via
  `bodyToFlux(t).collectList()`.

## Backward compat
Pure addition. No existing method signatures change. Consumers who don't need
bulk patch are unaffected.

## Naming
`patchCollection` instead of overloading `patch(JsonPatch)` because the existing
`patch(...)` family all takes `String id` as first arg; an id-less overload would
cause subtle method-resolution ambiguity. `patchCollection` makes the intent
explicit and maps cleanly to "PATCH the collection root".

## Test plan
- [x] Six new IT cases in `TestTmfClientIT`:
  - happy path (3-op patch, list of 3 returned in order)
  - custom return type (`patchCollection(jsonPatch, MyDto.class)`)
  - with-token variant
  - 4xx error mapping (`TmfClientException`, status 400)
  - 5xx error mapping (`TmfClientException`, status 500)
  - empty patch passes through (matches existing single-resource `patch` behaviour)
- [x] `mvn clean verify` green: 93 tests, 0 failures, 0 errors, 0 skipped (was 87 before).
- [x] Jacoco coverage thresholds (80% line / instruction / branch) all met.

## Followups
- `idemia-drom-ofs-adapter` migration to use this method (separate PR; will
  obsolete the adapter-local `ResourceInventoryPatchCreateClient`).
- `batch-drom-ofs-adapter` migration to use this method (cleans up its custom
  client; tech-debt removal).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a pure additive API surface that reuses existing auth/header validation, retry, and error-mapping patterns; main risk is limited to correct list deserialization and endpoint expectations for the new collection-root `PATCH`.
> 
> **Overview**
> Adds **collection-level JSON Patch** support to `TmfClient`/`TmfClientBaseImpl` via new `patchCollection(...)` and `patchCollectionWithToken(...)` overloads that `PATCH` the collection root (no `/{id}`) with `application/json-patch+json` and return `Mono<List<...>>`.
> 
> Implements the underlying WebClient call in `TmfClientCommonUtil.patchRequestList()` (Flux-to-List deserialization with existing header validation, retry, and error handling) and expands integration tests/mocks to cover success, custom element types, token-supplied calls, and 4xx/5xx error mapping; updates `CHANGELOG.md` for `1.1.9`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c94dee10ae54c06023f329efe252f334b7f30bc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->